### PR TITLE
set a global max-scale to 30

### DIFF
--- a/config/serving/configmaps/autoscaler.yaml
+++ b/config/serving/configmaps/autoscaler.yaml
@@ -13,6 +13,10 @@ data:
   # Leave a replica of each active revision available.
   min-scale: "2"
 
+  # A global ceiling to prevent infinite scaling.
+  # Individual revisions are still allowed to exceed this.
+  max-scale: "30"
+
   # (with above) never have activator in the request path.
   target-burst-capacity: "0"
 


### PR DESCRIPTION
Sets a global `max-scale` to 30, but doesn't limit individual revisions to exceed this when specified (`max-scale-limit`).