### PR TITLE
Fix: Apparently Kubernetes only accepts ALL not all.

### DIFF
--- a/config/serving/deployments/controlplane.yaml
+++ b/config/serving/deployments/controlplane.yaml
@@ -121,7 +121,7 @@ spec:
           runAsNonRoot: true
           capabilities:
             drop:
-            - all
+            - ALL
 
         ports:
         - name: profiling
@@ -184,7 +184,7 @@ spec:
           runAsNonRoot: true
           capabilities:
             drop:
-            - all
+            - ALL
 
         ports:
         - name: profiling


### PR DESCRIPTION
:bug: Switch all -> ALL when dropping capabilities

ref: https://github.com/knative-sandbox/eventing-rabbitmq/pull/954#pullrequestreview-1153348371

/kind bug