### PR TITLE
bump istio.io/api to last supported version before k8s.io 0.26.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/google/go-cmp v0.5.9
 	github.com/hashicorp/golang-lru v0.6.0
 	go.uber.org/zap v1.24.0
-	istio.io/api v0.0.0-20221128172210-2df01fb1b9e4
+	istio.io/api v0.0.0-20221212180111-09895d694711
 	k8s.io/api v0.25.5
 	k8s.io/apimachinery v0.25.5
 	k8s.io/client-go v0.25.5

--- a/go.sum
+++ b/go.sum
@@ -1035,8 +1035,8 @@ honnef.co/go/tools v0.0.0-20190523083050-ea95bdfd59fc/go.mod h1:rf3lG4BRIbNafJWh
 honnef.co/go/tools v0.0.1-2019.2.3/go.mod h1:a3bituU0lyd329TUQxRnasdCoJDkEUEAqEt0JzvZhAg=
 honnef.co/go/tools v0.0.1-2020.1.3/go.mod h1:X/FiERA/W4tHapMX5mGpAtMSVEeEUOyHaw9vFzvIQ3k=
 honnef.co/go/tools v0.0.1-2020.1.4/go.mod h1:X/FiERA/W4tHapMX5mGpAtMSVEeEUOyHaw9vFzvIQ3k=
-istio.io/api v0.0.0-20221128172210-2df01fb1b9e4 h1:s6oF3W29oBCh8Xd3Xxmq3txwhNgkflGie6IjxHsQXik=
-istio.io/api v0.0.0-20221128172210-2df01fb1b9e4/go.mod h1:oV64LW9BQmwkiP2KxXeOrktfTuLlHaV4ee3xPshNZuw=
+istio.io/api v0.0.0-20221212180111-09895d694711 h1:cSPlnd6clrp4UrPUos+HDCide9782r/NBudVHqjcnCc=
+istio.io/api v0.0.0-20221212180111-09895d694711/go.mod h1:oV64LW9BQmwkiP2KxXeOrktfTuLlHaV4ee3xPshNZuw=
 istio.io/client-go v1.16.0 h1:wIHRK9x1GbPm4AOeEMhHlpJL7uhNPhtVgzaxIGrIRGU=
 istio.io/client-go v1.16.0/go.mod h1:UV8SFeM2qNime5sobkr2m8oTCPxxVt9xCY4ol50U9YQ=
 k8s.io/api v0.25.5 h1:mqyHf7aoaYMpdvO87mqpol+Qnsmo+y09S0PMIXwiZKo=

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -620,7 +620,7 @@ gopkg.in/yaml.v2
 # gopkg.in/yaml.v3 v3.0.1
 ## explicit
 gopkg.in/yaml.v3
-# istio.io/api v0.0.0-20221128172210-2df01fb1b9e4
+# istio.io/api v0.0.0-20221212180111-09895d694711
 ## explicit; go 1.18
 istio.io/api/analysis/v1alpha1
 istio.io/api/meta/v1alpha1


### PR DESCRIPTION
Signed-off-by: Kenny Leung <kleung@chainguard.dev>