### PR TITLE
fix: public release with goreleaser

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -16,7 +16,6 @@ changelog:
   use: github-native
 
 release:
-  draft: true
   extra_files:
     - glob: "./serving.yaml"
       name_template: serving.yaml

--- a/hack/sign-images.sh
+++ b/hack/sign-images.sh
@@ -8,8 +8,8 @@ set -o nounset
 set -o pipefail
 
 if [[ ! -f serving.images ]]; then
-    echo "serving.images not found"
-    exit 1
+  echo "serving.images not found"
+  exit 1
 fi
 
 echo "Signing cosign images using Keyless..."


### PR DESCRIPTION
attempting to fix release, as `serving.yaml` is not included in release.
see https://github.com/chainguard-dev/hakn/releases/tag/v1.9.5

or maybe im missing something else
