### PR TITLE
upload serving.yaml artificat to the job workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -46,6 +46,11 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+      - uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3.1.2
+        with:
+          name: serving.yaml
+          path: ./serving.yaml
+
       - name: Post failure notice to Slack
         uses: rtCamp/action-slack-notify@12e36fc18b0689399306c2e0b3e0f2978b7f1ee7 # v2.2.0
         if: ${{ failure() }}


### PR DESCRIPTION
if for some reason goreleaser does not upload the artifact to the release we can recover from the workflow

it is nice to have