### PR TITLE
set resources request and limits for cpu and memory for the queue sidecar

### DIFF
--- a/config/serving/configmaps/deployment.yaml
+++ b/config/serving/configmaps/deployment.yaml
@@ -14,6 +14,22 @@ data:
   # and substituted here.
   queueSidecarImage: ko://knative.dev/serving/cmd/queue
 
+  # Sets the queue proxy's CPU request.
+  # If omitted, a default value (default "25m"), is used.
+  queue-sidecar-cpu-request: "25m"
+
+  # Sets the queue proxy's CPU limit.
+  # If omitted, no value is specified and the system default is used.
+  queue-sidecar-cpu-limit: "1000m"
+
+  # Sets the queue proxy's memory request.
+  # If omitted, no value is specified and the system default is used.
+  queue-sidecar-memory-request: "50Mi"
+
+  # Sets the queue proxy's memory limit.
+  # If omitted, no value is specified and the system default is used.
+  queue-sidecar-memory-limit: "800Mi"
+
   _example: |
     ################################
     #                              #


### PR DESCRIPTION
-set resources request and limits for cpu and memory for the queue sidecar

I was checking the queue sidecar, and they are pretty stable and those are initial values.
Today only the CPU request is being set the others are not. 

This will require a release if we want to use it right away, or we can wait till the next knative bump

Related to https://github.com/chainguard-dev/mono/issues/10880

reference from upstream: https://github.com/knative/serving/blob/main/config/core/configmaps/deployment.yaml#L24