### PR TITLE
remove duplicate additionalPrinterColumns

### DIFF
--- a/config/serving/200-imported/200-serving/100-resources/domain-mapping.yaml
+++ b/config/serving/200-imported/200-serving/100-resources/domain-mapping.yaml
@@ -150,16 +150,6 @@ spec:
                 url:
                   description: URL is the URL of this DomainMapping.
                   type: string
-      additionalPrinterColumns:
-        - name: URL
-          type: string
-          jsonPath: .status.url
-        - name: Ready
-          type: string
-          jsonPath: ".status.conditions[?(@.type=='Ready')].status"
-        - name: Reason
-          type: string
-          jsonPath: ".status.conditions[?(@.type=='Ready')].reason"
   names:
     kind: DomainMapping
     plural: domainmappings

--- a/hack/patches/14592.patch
+++ b/hack/patches/14592.patch
@@ -1,0 +1,21 @@
+diff --git a/vendor/knative.dev/serving/config/core/300-resources/domain-mapping.yaml b/vendor/knative.dev/serving/config/core/300-resources/domain-mapping.yaml
+index 8fdeea6..eacc869 100644
+--- a/vendor/knative.dev/serving/config/core/300-resources/domain-mapping.yaml
++++ b/vendor/knative.dev/serving/config/core/300-resources/domain-mapping.yaml
+@@ -150,16 +150,6 @@ spec:
+                 url:
+                   description: URL is the URL of this DomainMapping.
+                   type: string
+-      additionalPrinterColumns:
+-        - name: URL
+-          type: string
+-          jsonPath: .status.url
+-        - name: Ready
+-          type: string
+-          jsonPath: ".status.conditions[?(@.type=='Ready')].status"
+-        - name: Reason
+-          type: string
+-          jsonPath: ".status.conditions[?(@.type=='Ready')].reason"
+   names:
+     kind: DomainMapping
+     plural: domainmappings

--- a/vendor/knative.dev/serving/config/core/300-resources/domain-mapping.yaml
+++ b/vendor/knative.dev/serving/config/core/300-resources/domain-mapping.yaml
@@ -150,16 +150,6 @@ spec:
                 url:
                   description: URL is the URL of this DomainMapping.
                   type: string
-      additionalPrinterColumns:
-        - name: URL
-          type: string
-          jsonPath: .status.url
-        - name: Ready
-          type: string
-          jsonPath: ".status.conditions[?(@.type=='Ready')].status"
-        - name: Reason
-          type: string
-          jsonPath: ".status.conditions[?(@.type=='Ready')].reason"
   names:
     kind: DomainMapping
     plural: domainmappings


### PR DESCRIPTION
patch for https://github.com/knative/serving/pull/14592

remove duplicate 'additionalPrinterColumns' in domain-mapping resource, was seeing

```
error: map[string]interface {}(nil): yaml: unmarshal errors:
  line 153: mapping key "additionalPrinterColumns" already defined at line 31
```